### PR TITLE
Fix: RSS feed

### DIFF
--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -2,7 +2,7 @@ import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 
-export async function get(context) {
+export async function GET(context) {
 	const posts = await getCollection('blog');
 	return rss({
 		title: SITE_TITLE,


### PR DESCRIPTION
[joshmoody.org/rss.xml](https://joshmoody.org/rss.xml) returns 404

Changing `get` to `GET` (used in [example](https://docs.astro.build/en/recipes/rss/#:~:text=export%20function%20GET%28context%29%20%7B)) seems to fix RSS generation locally

Was curious so did a quick dig in the CHANGELOGS for [`astro`](https://github.com/withastro/astro/blob/main/packages/astro/CHANGELOG.md) and [`astro-rss`](https://github.com/withastro/astro/blob/main/packages/astro-rss/CHANGELOG.md) but couldn't find a mention, but did find [this older example](https://github.com/withastro/astro/blob/main/packages/astro-rss/CHANGELOG.md#:~:text=async%20function%20GET) that uses lowercase `get` in [3.0.0](https://github.com/withastro/astro/blob/main/packages/astro-rss/CHANGELOG.md#300)

Love your blog - take care